### PR TITLE
swapped red and green in set_pixel

### DIFF
--- a/library/pantilthat/pantilt.py
+++ b/library/pantilthat/pantilt.py
@@ -221,8 +221,8 @@ class PanTilt:
             self._check_int_range(c, 0, 255)
 
         index *= 3
-        self._pixels[index]   = red
-        self._pixels[index+1] = green
+        self._pixels[index]   = green
+        self._pixels[index+1] = red
         self._pixels[index+2] = blue
 
     def show(self):


### PR DESCRIPTION
Currently 255,0,0 passed to pantilthat.set_all will turn the neopixels to all green. In the pantilthat.set_pixel function, the red and green assignments need to be swapped so that RGB values passed to pantilthat.set_all generate the correct colours on the neopixels.   The order of colours is already this way round for the pantilthat.set_pixel_rgbw function. 