### PR TITLE
Fix set_pixel_rgbw

### DIFF
--- a/library/pantilthat/pantilt.py
+++ b/library/pantilthat/pantilt.py
@@ -300,8 +300,6 @@ class PanTilt:
 
         self.set_pixel(index, red, green, blue, white)
 
-        self._pixels[index+3] = white
-
     def set_pixel(self, index, red, green, blue, white=None):
         """Set a single pixel in the buffer.
 


### PR DESCRIPTION
Spurious setting of an index in set_pixel_rgbw causes certain LEDs to fail when used. To reproduce (with WS2812 GRBW array):

```python
import pantilthat as hat

hat.light_mode(hat.WS2812)
hat.light_type(hat.GRBW)
for i in range(8):
    hat.set_pixel_rgbw(i, 0, 64, 0, 0, 0)
hat.show()
```

This *should* set all LEDs to green but a couple of the early ones end up off.