### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/library/CHANGELOG.txt
+++ b/library/CHANGELOG.txt
@@ -1,3 +1,8 @@
+0.0.5
+-----
+
+* Bugfix: deferred setup to prevent side-effects upon import
+
 0.0.4
 -----
 

--- a/library/pantilthat/__init__.py
+++ b/library/pantilthat/__init__.py
@@ -12,26 +12,42 @@ from .pantilt import PanTilt, WS2812, PWM, RGB, GRB, RGBW, GRBW
 
 __version__ = '0.0.4'
 
-pantilthat = PanTilt(i2c_bus=SMBus(1))
+_is_setup = False
+pantilthat = None
 
-idle_timeout = pantilthat.idle_timeout
-servo_enable = pantilthat.servo_enable
-servo_pulse_max = pantilthat.servo_pulse_max
-servo_pulse_min = pantilthat.servo_pulse_min
+def setup():
+    global _is_setup, pantilthat
+    if _is_setup:
+        return
 
-brightness = pantilthat.brightness
-clear = pantilthat.clear
-light_mode = pantilthat.light_mode
-light_type = pantilthat.light_type
-set_all = pantilthat.set_all
-set_pixel = pantilthat.set_pixel
-set_pixel_rgbw = pantilthat.set_pixel_rgbw
-show = pantilthat.show
+    pantilthat = PanTilt(i2c_bus=SMBus(1))
+    _is_setup = True
 
-servo_one = pantilthat.servo_one
-pan = servo_one
-get_pan = get_servo_one = pantilthat.get_servo_one
+for method in "idle_timeout", "servo_enable", "servo_pulse_min", "servo_pulse_max", "brightness", "clear", "light_mode", "light_type", "set_all", "set_pixel", "set_pixel_rgbw", "show", "pan", "servo_one", "get_pan", "get_servo_one", "tilt", "servo_two", "get_tilt", "get_servo_two":
+    def wrap(*args, **kwargs):
+        setup()
+        pantilthat.getattr(method)(*args, **kwargs)
 
-servo_two = pantilthat.servo_two
-tilt = servo_two
-get_tilt = get_servo_two = pantilthat.get_servo_two
+    globals()[method] = wrap
+
+#idle_timeout = pantilthat.idle_timeout
+#servo_enable = pantilthat.servo_enable
+#servo_pulse_max = pantilthat.servo_pulse_max
+#servo_pulse_min = pantilthat.servo_pulse_min
+
+#brightness = pantilthat.brightness
+#clear = pantilthat.clear
+#light_mode = pantilthat.light_mode
+#light_type = pantilthat.light_type
+#set_all = pantilthat.set_all
+#set_pixel = pantilthat.set_pixel
+#set_pixel_rgbw = pantilthat.set_pixel_rgbw
+#show = pantilthat.show
+
+#servo_one = pantilthat.servo_one
+#pan = servo_one
+#get_pan = get_servo_one = pantilthat.get_servo_one
+
+#servo_two = pantilthat.servo_two
+#tilt = servo_two
+#get_tilt = get_servo_two = pantilthat.get_servo_two

--- a/library/pantilthat/__init__.py
+++ b/library/pantilthat/__init__.py
@@ -2,7 +2,7 @@ from sys import exit, version_info
 
 from .pantilt import PanTilt, WS2812, PWM, RGB, GRB, RGBW, GRBW
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 
 pantilthat = PanTilt()
 

--- a/library/pantilthat/__init__.py
+++ b/library/pantilthat/__init__.py
@@ -1,53 +1,29 @@
 from sys import exit, version_info
 
-try:
-    from smbus import SMBus
-except ImportError:
-    if version_info[0] < 3:
-        exit("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
-    elif version_info[0] == 3:
-        exit("This library requires python3-smbus\nInstall with: sudo apt-get install python3-smbus")
-
 from .pantilt import PanTilt, WS2812, PWM, RGB, GRB, RGBW, GRBW
 
 __version__ = '0.0.4'
 
-_is_setup = False
-pantilthat = None
+pantilthat = PanTilt()
 
-def setup():
-    global _is_setup, pantilthat
-    if _is_setup:
-        return
+idle_timeout = pantilthat.idle_timeout
+servo_enable = pantilthat.servo_enable
+servo_pulse_max = pantilthat.servo_pulse_max
+servo_pulse_min = pantilthat.servo_pulse_min
 
-    pantilthat = PanTilt(i2c_bus=SMBus(1))
-    _is_setup = True
+brightness = pantilthat.brightness
+clear = pantilthat.clear
+light_mode = pantilthat.light_mode
+light_type = pantilthat.light_type
+set_all = pantilthat.set_all
+set_pixel = pantilthat.set_pixel
+set_pixel_rgbw = pantilthat.set_pixel_rgbw
+show = pantilthat.show
 
-for method in "idle_timeout", "servo_enable", "servo_pulse_min", "servo_pulse_max", "brightness", "clear", "light_mode", "light_type", "set_all", "set_pixel", "set_pixel_rgbw", "show", "pan", "servo_one", "get_pan", "get_servo_one", "tilt", "servo_two", "get_tilt", "get_servo_two":
-    def wrap(*args, **kwargs):
-        setup()
-        pantilthat.getattr(method)(*args, **kwargs)
+servo_one = pantilthat.servo_one
+pan = servo_one
+get_pan = get_servo_one = pantilthat.get_servo_one
 
-    globals()[method] = wrap
-
-#idle_timeout = pantilthat.idle_timeout
-#servo_enable = pantilthat.servo_enable
-#servo_pulse_max = pantilthat.servo_pulse_max
-#servo_pulse_min = pantilthat.servo_pulse_min
-
-#brightness = pantilthat.brightness
-#clear = pantilthat.clear
-#light_mode = pantilthat.light_mode
-#light_type = pantilthat.light_type
-#set_all = pantilthat.set_all
-#set_pixel = pantilthat.set_pixel
-#set_pixel_rgbw = pantilthat.set_pixel_rgbw
-#show = pantilthat.show
-
-#servo_one = pantilthat.servo_one
-#pan = servo_one
-#get_pan = get_servo_one = pantilthat.get_servo_one
-
-#servo_two = pantilthat.servo_two
-#tilt = servo_two
-#get_tilt = get_servo_two = pantilthat.get_servo_two
+servo_two = pantilthat.servo_two
+tilt = servo_two
+get_tilt = get_servo_two = pantilthat.get_servo_two

--- a/library/setup.py
+++ b/library/setup.py
@@ -39,7 +39,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
 
 setup(
     name            = 'pantilthat',
-    version         = '0.0.4',
+    version         = '0.0.5',
     author          = 'Philip Howard',
     author_email    = 'phil@pimoroni.com',
     description     = """Python library for driving Pimoroni PanTiltHAT!""",

--- a/packaging/CHANGELOG
+++ b/packaging/CHANGELOG
@@ -1,3 +1,9 @@
+pantilthat (0.0.5) stable; urgency=low
+
+  * Bugfix: deferred setup to prevent side-effects upon import
+
+ -- Phil Howard <phil@pimoroni.com>  Wed, 24 Jan 2018 00:00:00 +0000
+
 pantilthat (0.0.4) stable; urgency=low
 
   * New: get_pan and get_tilt methods to read back servo position

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+pantilthat (0.0.5) stable; urgency=low
+
+  * Bugfix: deferred setup to prevent side-effects upon import
+
+ -- Phil Howard <phil@pimoroni.com>  Wed, 24 Jan 2018 00:00:00 +0000
+
 pantilthat (0.0.4) stable; urgency=low
 
   * New: get_pan and get_tilt methods to read back servo position


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the Pan Tilt HAT library to ensure that it does not perform any module setup or i2c communication when initially imported.

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488