### PR TITLE
Added neopixel-blinkt library

### DIFF
--- a/neopixel-blinkt/CHANGELOG.txt
+++ b/neopixel-blinkt/CHANGELOG.txt
@@ -1,0 +1,5 @@
+0.0.1
+-----
+
+* Initial Revision
+

--- a/neopixel-blinkt/LICENSE.txt
+++ b/neopixel-blinkt/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Pimoroni Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/neopixel-blinkt/MANIFEST.in
+++ b/neopixel-blinkt/MANIFEST.in
@@ -1,0 +1,5 @@
+include CHANGELOG.txt
+include LICENSE.txt
+include README.rst
+include setup.py
+include blinkt.py

--- a/neopixel-blinkt/README.md
+++ b/neopixel-blinkt/README.md
@@ -1,0 +1,1 @@
+#Blinkt with Pan-Tilt HAT and Neopixel Library

--- a/neopixel-blinkt/README.rst
+++ b/neopixel-blinkt/README.rst
@@ -1,0 +1,42 @@
+.. figure:: blinkt-logo.png
+   :alt: Blinkt!
+
+   Blinkt compatibility for a Pan-Tilt HAT and an Adafruit Neopixel!
+
+
+https://shop.pimoroni.com/products/blinkt
+https://shop.pimoroni.com/products/pan-tilt-hat
+https://shop.pimoroni.com/products/neopixel-stick-8-x-5050-rgbw-leds
+
+Run programs designed for the Blinkt! on a Pan-Tilt HAT with an Adafruit Neopixel strip
+
+
+Installing
+----------
+
+Manual install Python 2:
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``cd`` to the library directory, and run:
+
+.. code:: bash
+
+    sudo python setup.py install
+
+Manual install Python 3:
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``cd`` to the library directory, and run:
+
+.. code:: bash
+
+    sudo python3 setup.py install
+
+
+Documentation & Support
+-----------------------
+
+-  Blinkt!      - https://learn.pimoroni.com/blinkt
+-  Pan-Tilt HAT - https://learn.pimoroni.com/pan-tilt-hat
+-  Neop Pixel   - https://learn.adafruit.com/adafruit-neopixel-uberguide
+

--- a/neopixel-blinkt/blinkt.py
+++ b/neopixel-blinkt/blinkt.py
@@ -1,0 +1,76 @@
+"""Library for Pimoroni Blinkt! programs compatibility with a Pimoroni Pan-Tilt HAT and an Adafruit Neopixel strip"""
+import sys
+import pantilthat
+import atexit
+import signal
+
+_clear_on_exit = True
+_brightness    = 0.2
+NUM_PIXELS     = 8
+
+def _exit():
+    if _clear_on_exit:
+        clear()
+        show()
+
+
+def set_brightness(brightness):
+    """Set the brightness of all pixels
+
+    :param brightness: Brightness: 0.0 to 1.0
+    """
+
+    if brightness < 0 or brightness > 1:
+        raise ValueError("Brightness should be between 0.0 and 1.0")
+
+    global _brightness
+    _brightness = brightness
+
+
+def clear():
+    pantilthat.clear()
+
+
+def show():
+    pantilthat.show()
+
+
+def set_all(r, g, b, brightness=None):
+    global _brightness
+    if brightness is not None:
+        _brightness = brightness
+    pantilthat.set_all(int(r*_brightness), int(g*_brightness), int(b*_brightness))
+
+
+def set_pixel(x, r, g, b, brightness=None):
+    global _brightness
+    if brightness is not None:
+        _brightness = brightness
+    pantilthat.set_pixel(x, int(r*_brightness), int(g*_brightness), int(b*_brightness))
+
+
+def set_clear_on_exit(value=True):
+    """Set whether Blinkt! should be cleared upon exit
+
+    By default Blinkt! will turn off the pixels on exit, but calling::
+
+        blinkt.set_clear_on_exit(False)
+
+    Will ensure that it does not.
+
+    :param value: True or False (default True)
+    """
+    global _clear_on_exit
+    _clear_on_exit = value
+
+
+def interrupt_handler(signum, frame):
+    print("\rKeyboardInterrupt")
+    sys.exit(128+signum)
+
+
+# Module Initialisation
+pantilthat.light_mode(pantilthat.WS2812)
+pantilthat.light_type(pantilthat.GRBW)
+atexit.register(_exit)
+signal.signal(signal.SIGINT, interrupt_handler)

--- a/neopixel-blinkt/setup.cfg
+++ b/neopixel-blinkt/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+exclude =
+	.git,
+	__pycache__

--- a/neopixel-blinkt/setup.py
+++ b/neopixel-blinkt/setup.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2016 Pimoroni.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+classifiers = ['Development Status :: 5 - Production/Stable',
+               'Operating System :: POSIX :: Linux',
+               'License :: OSI Approved :: MIT License',
+               'Intended Audience :: Developers',
+               'Programming Language :: Python :: 2.7',
+               'Programming Language :: Python :: 3',
+               'Topic :: Software Development',
+               'Topic :: System :: Hardware']
+
+setup(
+    name='neopixel-blinkt',
+    version='0.0.1',
+    author='David Ruck',
+    author_email='pimoroni@druck.org.uk',
+    description="""Python library to allow Pimoroni Blinkt! programs to run with a Pimoroni Pan-Tilt HAT and an Adafruit Neopixel strip""",
+    long_description=open('README.rst').read() + '\n' + open('CHANGELOG.txt').read(),
+    license='MIT',
+    keywords='Raspberry Pi Neopixel',
+    url='http://www.pimoroni.com',
+    classifiers=classifiers,
+    py_modules=['blinkt'],
+    install_requires=['pantilthat']
+)


### PR DESCRIPTION
Added neopixel-blinkt containing a library which will allow programs written for the Pimoroni Blinkt! LED strip to work without modification, with the Pimoroni Pan-Tilt HAT and an Adafruit Neopixel strip.